### PR TITLE
Fixed main entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "calendar-tiler",
   "version": "1.0.2",
   "description": "Algorithm for tiling a calendar filled with appointments",
-  "main": "index.js",
+  "main": "calendarTiler.js",
   "dependencies": {},
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Main entry in `package.json` points to non-existing file, causing `require()` to fail.